### PR TITLE
Handle cancelled deployments without a pending deployment record

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "author": "",
   "private": true,
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",

--- a/src/deployments/deployments.service.spec.ts
+++ b/src/deployments/deployments.service.spec.ts
@@ -90,7 +90,7 @@ describe('DeploymentService', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     clearCollection('deployments');
   });
 

--- a/src/resumes/resumes.controller.spec.ts
+++ b/src/resumes/resumes.controller.spec.ts
@@ -53,7 +53,7 @@ describe('ResumesController', () => {
 
   afterEach(async () => {
     await clearDb();
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   afterAll(async () => {

--- a/src/resumes/resumes.service.spec.ts
+++ b/src/resumes/resumes.service.spec.ts
@@ -52,7 +52,7 @@ describe('ResumesService', () => {
   });
 
   afterEach(async () => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     await clearDb();
   });
 


### PR DESCRIPTION
We can get into a situation where we a deployment is in progress/pending but has no entry in the pending deployments. If a user tries to cancel that deployment, the GeneratorService will never see the cancellation request, as it relies on pending deployment records to know which deployments to process.

This PR backfills the pending deployment record when a user requests cancellation if the pending deployment record is misisng.